### PR TITLE
BUG: boxcox data constancy check #5112 #10978

### DIFF
--- a/scipy/stats/morestats.py
+++ b/scipy/stats/morestats.py
@@ -950,7 +950,8 @@ def boxcox(x, lmbda=None, alpha=None):
     Parameters
     ----------
     x : ndarray
-        Input array.  Must be positive 1-dimensional.  Must not be constant.
+        Input array. Must be positive 1-dimensional. If `lmbda` is None,
+        array must not be constant.
     lmbda : {None, scalar}, optional
         If `lmbda` is not None, do the transformation for that value.
 
@@ -1036,7 +1037,7 @@ def boxcox(x, lmbda=None, alpha=None):
     if x.size == 0:
         return x
 
-    if np.all(x == x[0]):
+    if (lmbda is None) and np.all(x == x[0]):
         raise ValueError("Data must not be constant.")
 
     if any(x <= 0):

--- a/scipy/stats/morestats.py
+++ b/scipy/stats/morestats.py
@@ -1037,9 +1037,6 @@ def boxcox(x, lmbda=None, alpha=None):
     if x.size == 0:
         return x
 
-    if (lmbda is None) and np.all(x == x[0]):
-        raise ValueError("Data must not be constant.")
-
     if any(x <= 0):
         raise ValueError("Data must be positive.")
 
@@ -1047,6 +1044,9 @@ def boxcox(x, lmbda=None, alpha=None):
         return special.boxcox(x, lmbda)
 
     # If lmbda=None, find the lmbda that maximizes the log-likelihood function.
+    if np.all(x == x[0]):
+        raise ValueError("Data must not be constant.")
+
     lmax = boxcox_normmax(x, method='mle')
     y = boxcox(x, lmax)
 


### PR DESCRIPTION
Perform data constancy check only when `lmbda` parameter is not passed. There is no reason to fail at runtime when pre-fitted `lmbda` value is passed to the transform. When running function at inference time (say, on a single value array), it should be able to perform desired transformation.

See related tickets #5112 #10978

<!-- 
Thanks for contributing a pull request! Please ensure that
your PR satisfies the checklist before submitting:
http://scipy.github.io/devdocs/dev/contributor/development_workflow.html#checklist-before-submitting-a-pr

Also, please name and describe your PR as you would write a
commit message:
https://docs.scipy.org/doc/numpy/dev/development_workflow.html#writing-the-commit-message

Note that we are a team of volunteers; we appreciate your
patience during the review process.

Again, thanks for contributing!
-->

#### Reference issue
#5112 #10978

#### What does this implement/fix?
Performs additional check, if lmbda parameter is passed (not None), do not perform data constancy check.

#### Additional information
<!--Any additional information you think is important.-->